### PR TITLE
Explicitly label the birth name in GEDCOM export

### DIFF
--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -1304,7 +1304,7 @@ class GedcomWriter(UpdateCallback):
 
         self._writeln(1, 'NAME', gedcom_name)
         if int(name.get_type()) == NameType.BIRTH:
-            pass
+          self._writeln(2, 'TYPE', 'birth')
         elif int(name.get_type()) == NameType.MARRIED:
             self._writeln(2, 'TYPE', 'married')
         elif int(name.get_type()) == NameType.AKA:


### PR DESCRIPTION
See discussion at https://gramps.discourse.group/t/distinguish-birth-and-married-names-in-ged-file/815/7 . This follows the GEDCOM 5.5.1 support for name types.